### PR TITLE
Update notifications plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
+    <dependency id="cordova-plugin-app-event" />
 
     <!-- info -->
     <info>
@@ -51,7 +52,6 @@
 
     <!-- ios -->
     <platform name="ios">
-        <dependency id="cordova-plugin-registerusernotificationsettings" url="https://github.com/katzer/cordova-common-registerusernotificationsettings" />
         <config-file target="config.xml" parent="/*">
             <feature name="LocalNotification">
                 <param name="ios-package" value="APPLocalNotification" onload="true" />

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -25,7 +25,7 @@
 #import "APPLocalNotificationOptions.h"
 #import "UIApplication+APPLocalNotification.h"
 #import "UILocalNotification+APPLocalNotification.h"
-#import "AppDelegate+APPRegisterUserNotificationSettings.h"
+#import "AppDelegate+APPAppEvent.h"
 
 @interface APPLocalNotification ()
 


### PR DESCRIPTION
Use cordova-plugin-app-event instead of outdated cordova-plugin-registerusernotificationsettings. Using these two plugins at the same time lead to build conflict. cordova-plugin-registerusernotificationsettings is no longer maintained, cordova-plugin-app-event is its successor.
